### PR TITLE
Se agrega el archivo requirements.txt y un poco de documentación al respecto

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,6 +2,7 @@
 .vscode
 .ipynb_checkpoints
 __pycache__
+/.venv/
 files/*
 *.csv
 *.xlsx

--- a/README.md
+++ b/README.md
@@ -17,6 +17,18 @@ python main.py
 
 Nota: En promedio, el programa tarda 1.5 seg por registro, con una complejidad lineal.
 
+### Uso sin conda
+
+Es posible ejecutar este proyecto en cualquier entorno con python instalando los
+requisitos listados en `requirements.txt`. Una opción es la siguiente:
+
+```shell-session
+$ python -m venv .venv
+$ source .venv/bin/activate
+(.venv) $ pip install -r requirements.txt
+(.venv) $ python main.py
+```
+
 ## Lógica general del programa
 
 1. Lee el insumo (archivo excel con lista de sitios de noticias).

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,5 @@
+beautifulsoup4
+requests
+pandas
+numpy
+lxml


### PR DESCRIPTION
Esto es para las personas que no usamos conda o que tenemos algún otro entorno python. La existencia de un archivo `requirements.txt` es un patrón común en python para documentar las dependencias del proyecto. Es posible fijarlas a versiones específicas pero sospecho que las versiones que jale pip funcionan bien en general.

Además se agrega al readme un poco de información sobre cómo usar este archivo para quienes así lo deseen. Esto baja la barrera de entrada a la colaboración con el proyecto.