### PR TITLE
Algunos errores que atrapó el linter

### DIFF
--- a/aux_functions.py
+++ b/aux_functions.py
@@ -1,6 +1,5 @@
 import numpy as np
 import requests
-import lxml.html as html
 from bs4 import BeautifulSoup
 
 

--- a/main.py
+++ b/main.py
@@ -92,7 +92,7 @@ for i in df[df.elsol_dummy].index:
         gtm = soup.find_all("script")
         for x in gtm:
             if 'dataLayer.push({"tags"' in x.text:
-                gtm_tags = re.search("\$\[.*\]", x.text).group()
+                gtm_tags = re.search("$[.*]", x.text).group()
                 gtm_tags = gtm_tags[2:-1]
                 break
         df.loc[i, "tags"] = gtm_tags

--- a/main.py
+++ b/main.py
@@ -92,7 +92,7 @@ for i in df[df.elsol_dummy].index:
         gtm = soup.find_all("script")
         for x in gtm:
             if 'dataLayer.push({"tags"' in x.text:
-                gtm_tags = re.search("$[.*]", x.text).group()
+                gtm_tags = re.search("\$\[.*\]", x.text).group()
                 gtm_tags = gtm_tags[2:-1]
                 break
         df.loc[i, "tags"] = gtm_tags

--- a/main.py
+++ b/main.py
@@ -1,7 +1,3 @@
-import os
-from bs4 import BeautifulSoup
-import requests
-import lxml.html as html
 import pandas as pd
 import re
 import numpy as np


### PR DESCRIPTION
Corrí `flake8` contra los archivos `main.py` y `aux_functions.py` y encontró estos errores simples. Tener solamente las dependencias usadas hace el código un pelito más fácil de entender. Y quitar las secuencias de escape innecesarias de una expresión regular hacen la expresión tantito más fácil de entender también.

Había también en el linter los siguientes errores que no corregí:

```
aux_functions.py:13:9: E722 do not use bare 'except'
aux_functions.py:18:5: E722 do not use bare 'except'
main.py:110:9: E722 do not use bare 'except'
main.py:125:9: E722 do not use bare 'except'
main.py:130:5: E722 do not use bare 'except'
main.py:160:9: E722 do not use bare 'except'
main.py:171:9: E722 do not use bare 'except'
main.py:237:1: E722 do not use bare 'except'
```

Estos requieren una revisión más detallada. La idea es que un except sin una excepción específica o con una muy amplia (como lo sería `except Exception:`) podría estar deteniendo errores que de hecho queremos ver. Lo mejor es manejar los errores que se quieren manejar _uno a uno_ haciendo cosas como `except KeyError:` y dejando que el resto de las excepciones suban, lo que permitirá un proceso de depuración más sencillo.